### PR TITLE
event-function-add9

### DIFF
--- a/app/controllers/public/events_controller.rb
+++ b/app/controllers/public/events_controller.rb
@@ -22,15 +22,21 @@ class Public::EventsController < ApplicationController
     # if current_user.event.present?
     # flash[:notice] = 'イベント申請できるのは１件のみです'
     # else
+    
+    # e = Event.find_by(user_id: current_user.id)
+    if @event.user_id.present?
       if @event.save!
         @event.update(event_status: 3)
-        flash[:notice] = 'イベントを申請しました'
+        flash[:notice] = 'イベントを申請しましたyo'
         redirect_to root_path
       else
         flash[:notice] = '申請に失敗しました'
         render action: :new
       end
-    # end
+    else
+      flash[:notice] = 'イベント申請は１件までです'
+      redirect_to events_path
+    end
   end
     
   def destroy

--- a/app/views/public/events/index.html.erb
+++ b/app/views/public/events/index.html.erb
@@ -1,21 +1,20 @@
 <div class="container">
     <% if user_signed_in? %>
       <div class="row">
-         <div class="c-toparea">
           <% @events.each do |event| %>
-            <% if event.event_status == 3 %>
-              <p class="c-red">あなたが申請中のイベント</p>
-              <div class="c-toparea-info">
-                <p class="text-center">申請できるイベントは一人１つまでです</p>
-                <ul>
-                  <li>イベント名：<%=link_to event.title, event_path(event.id) %></li>
-                  <li>種目：<%= event.event1 %></li>
-                </ul>
-                
+            <div class="c-toparea">
+              <% if event.event_status == 3 %>
+                <p class="c-red">あなたが申請中のイベント</p>
+                <div class="c-toparea-info">
+                  <p class="text-center">申請できるイベントは一人１つまでです</p>
+                  <ul>
+                    <li>イベント名：<%=link_to event.title, event_path(event.id) %></li>
+                    <li>種目：<%= event.event1 %></li>
+                  </ul>
+                </div>
               </div>
             <% end %>
           <% end %>
-         </div>
       </div>
     <% else %>
       <i class="fas fa-plus-circle"><%= link_to "ログインしてイベント申請", new_event_path %></i>


### PR DESCRIPTION
- 中間テーブルを作らないと申請できるイベントは１つですを実装できない可能性が高い
- controllerを中心にエラーを探しました。
- Event.find(1).user.idのような形では呼び出せるがUserからEventを特定することが出来ないので中間テーブル必要？